### PR TITLE
🚨 Add type annotation for transmute use

### DIFF
--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -63,7 +63,7 @@ impl TryFrom<OwnedValue> for AuthorityFeatures {
 
     fn try_from(v: OwnedValue) -> Result<Self, Self::Error> {
         // safe because AuthorityFeatures has repr u32
-        Ok(unsafe { std::mem::transmute(<u32>::try_from(v)?) })
+        Ok(unsafe { std::mem::transmute::<u32, AuthorityFeatures>(v.try_into()?) })
     }
 }
 


### PR DESCRIPTION
Apparently, clippy wants us to do this now:

```rust
error: transmute used without annotations
  --> src/policykit1.rs:66:31
   |
66 |         Ok(unsafe { std::mem::transmute(<u32>::try_from(v)?) })
   |                               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<u32, policykit1::AuthorityFeatures>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
   = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
```