### PR TITLE
derive serde::Serialize for TemporaryAuthorization

### DIFF
--- a/src/policykit1.rs
+++ b/src/policykit1.rs
@@ -69,7 +69,7 @@ impl TryFrom<OwnedValue> for AuthorityFeatures {
 
 /// Details of a temporary authorization as provided by the /org/freedesktop/PolicyKit1/Authority
 /// object in the system bus.
-#[derive(Debug, Type, Deserialize)]
+#[derive(Debug, Type, Deserialize, Serialize)]
 pub struct TemporaryAuthorization {
     /// An opaque identifier for the temporary authorization.
     pub id: String,


### PR DESCRIPTION
Hi there. I've been using this patch in my project for a while now to serialize `TemporaryAuhorization` types for mocks in tests. I haven't noticed any issues so far. Here's a PR in case you want to add to your project too.