### PR TITLE
⬆️ Bump bytes and hashbrown to fix Dependabot security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "hex"


### PR DESCRIPTION
## Summary

Addresses the two open Dependabot security alerts for this repository by bumping the affected
transitive dependencies (lockfile only) to their first patched releases. Each bump is a separate
atomic commit touching only `Cargo.lock`.

| Dependency | Severity | Advisory | Fix |
|------------|----------|----------|-----|
| `bytes` | Medium | Integer overflow in `BytesMut::reserve` (affects `>= 1.2.1, < 1.11.1`) | 1.5.0 → 1.11.1 |
| `hashbrown` | High | Non-canonical Borsh serialization of `HashMap` (affects `0.15.0`) | 0.15.0 → 0.15.1 |

## Verification

- `cargo build --all-features` — passes
- `cargo test --all-features` — passes
